### PR TITLE
Working

### DIFF
--- a/src/main/java/arquitetura/representation/Class.java
+++ b/src/main/java/arquitetura/representation/Class.java
@@ -1,5 +1,14 @@
 package arquitetura.representation;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
 import arquitetura.exceptions.AttributeNotFoundException;
 import arquitetura.exceptions.MethodNotFoundException;
 import arquitetura.flyweights.VariantFlyweight;
@@ -10,14 +19,8 @@ import arquitetura.representation.relationship.RelationshiopCommons;
 import arquitetura.representation.relationship.Relationship;
 import arquitetura.touml.Types.Type;
 import arquitetura.touml.VisibilityKind;
+
 import com.rits.cloning.Cloner;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 
 /**
  * 


### PR DESCRIPTION
Cara.. arrumei um bug que estava dando na hora de criar o ArchitectureBuilder.
No projeto da Thai estava dando NullPointer, daí fui verificar, realmente o "ReaderConfig.load()" tem que ser chamado antes da instanciação do ModelHelper. Se você for ver bem, em algum lugar lá na cadeia de invocação o método setSmartyProfile() é chamado antes do load(), o que faz dar pau.
Não sei porque isso não deu pau no meu projeto, mas enfim....
Abraços.
PS: Dessa vez não vou dar push no projeto sem testes uehueheuheuhe
